### PR TITLE
Hook pan handlers into ImageAnnotator

### DIFF
--- a/src/components/ImageAnnotator/index.tsx
+++ b/src/components/ImageAnnotator/index.tsx
@@ -25,7 +25,8 @@ const ImageAnnotator = () => {
 
     // Custom hooks for core functionality
     const {
-        zoom, pan, onWheel, zoomToFit, zoomIn, zoomOut
+        zoom, pan, onWheel, zoomToFit, zoomIn, zoomOut,
+        startPan, updatePan, endPan
     } = usePanZoom();
 
     const {
@@ -149,14 +150,16 @@ const ImageAnnotator = () => {
     // Pointer event handlers
     const onPointerDown = (e: React.PointerEvent) => {
         if (!image) return;
-        const mouse = getMousePoint(e, containerRef);
-        const img = screenToImage(mouse, zoom, pan);
         (e.target as HTMLElement).setPointerCapture(e.pointerId);
 
         // Panning (tool or spacebar)
         if (tool === "pan" || isPanning) {
+            startPan(e);
             return;
         }
+
+        const mouse = getMousePoint(e, containerRef);
+        const img = screenToImage(mouse, zoom, pan);
 
         // Start drawing tools
         if (tool === "rect") {
@@ -198,6 +201,10 @@ const ImageAnnotator = () => {
     };
 
     const onPointerMove = (e: React.PointerEvent) => {
+        if (tool === "pan" || isPanning) {
+            updatePan(e);
+            return;
+        }
         if (!image) return;
         const mouse = getMousePoint(e, containerRef);
         const img = screenToImage(mouse, zoom, pan);
@@ -220,6 +227,10 @@ const ImageAnnotator = () => {
     };
 
     const onPointerUp = () => {
+        if (tool === "pan" || isPanning) {
+            endPan();
+            return;
+        }
         if (draftRect) {
             finalizeDraftRect();
             endOp();

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { type Point } from '../types';
-import { clamp, getMousePoint, screenToImage } from '../utils/coordinates';
+import { clamp, screenToImage } from '../utils/coordinates';
 
 interface UsePanZoomProps {
     initialZoom?: number;
@@ -19,17 +19,25 @@ const usePanZoom = ({
     const [isPanning, setIsPanning] = useState(false);
 
     const startPan = (e: React.PointerEvent) => {
-        const mouse = getMousePoint(e, e.currentTarget as unknown as React.RefObject<HTMLDivElement>);
+        const bounds = (e.currentTarget as Element).getBoundingClientRect();
+        const mouse = {
+            x: e.clientX - bounds.left,
+            y: e.clientY - bounds.top,
+        };
         panStart.current = { x: mouse.x - pan.x, y: mouse.y - pan.y };
         setIsPanning(true);
     };
 
     const updatePan = (e: React.PointerEvent) => {
         if (!panStart.current) return;
-        const mouse = getMousePoint(e, e.currentTarget as unknown as React.RefObject<HTMLDivElement>);
+        const bounds = (e.currentTarget as Element).getBoundingClientRect();
+        const mouse = {
+            x: e.clientX - bounds.left,
+            y: e.clientY - bounds.top,
+        };
         setPan({
             x: mouse.x - panStart.current.x,
-            y: mouse.y - panStart.current.y
+            y: mouse.y - panStart.current.y,
         });
     };
 


### PR DESCRIPTION
## Summary
- Simplify pan/zoom hook by computing mouse coordinates from event bounds instead of getMousePoint
- Wire ImageAnnotator pointer events to start, update and end panning when pan tool or spacebar is active

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd34fb2883329c475100db201502