### PR TITLE
feat: reset annotations when loading new image

### DIFF
--- a/src/components/ImageAnnotator/index.tsx
+++ b/src/components/ImageAnnotator/index.tsx
@@ -30,11 +30,6 @@ const ImageAnnotator = () => {
     } = usePanZoom();
 
     const {
-        image, imageName,
-        handleFileInput, handleDrop, handleDragOver, handleImportJson
-    } = useImageLoader();
-
-    const {
         shapes, setShapes, selectedId, setSelectedId,
         draftRect, draftPoly, draftBezier, hover,
         createRect, updateDraftRect, finalizeDraftRect,
@@ -44,6 +39,11 @@ const ImageAnnotator = () => {
         startDrag, updateDrag, endDrag, updateHover,
         deleteSelected, moveSelectedByArrows
     } = useShapeManipulation();
+
+    const {
+        image, imageName,
+        handleFileInput, handleDrop, handleDragOver, handleImportJson
+    } = useImageLoader(() => setShapes([]));
 
     const {
         beginOp, endOp, undo, redo, cancelOp, canUndo, canRedo

--- a/src/hooks/useImageLoader.ts
+++ b/src/hooks/useImageLoader.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { type AnnotationBundle, type Shape } from '../types';
 
-const useImageLoader = () => {
+const useImageLoader = (onReset?: () => void) => {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [imageName, setImageName] = useState<string | undefined>(undefined);
 
@@ -12,6 +12,7 @@ const useImageLoader = () => {
         img.onload = () => {
             setImage(img);
             setImageName(file.name);
+            onReset?.();
         };
 
         img.onerror = () => {
@@ -31,6 +32,7 @@ const useImageLoader = () => {
         img.onload = () => {
             setImage(img);
             setImageName(name);
+            onReset?.();
         };
         img.src = dataUrl;
     };


### PR DESCRIPTION
## Summary
- allow `useImageLoader` to accept a reset callback that clears annotation state after images load
- ensure `ImageAnnotator` passes `setShapes([])` so annotations reset on each new image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a558743bd88332b3a92aa831d0e195