### PR TITLE
Render polygon for closed polylines

### DIFF
--- a/src/components/shapes/PolylineRenderer.tsx
+++ b/src/components/shapes/PolylineRenderer.tsx
@@ -19,15 +19,26 @@ const PolylineRenderer: React.FC<PolylineRendererProps> = ({
 
     return (
         <>
-            <polyline
-                points={pointsStr}
-                fill={shape.closed ? (shape.fill || "rgba(34,197,94,0.08)") : "none"}
-                stroke={shape.stroke || "#22c55e"}
-                strokeWidth={2}
-                strokeLinejoin="round"
-                strokeLinecap="round"
-                className={shape.closed ? 'closed' : ''}
-            />
+            {shape.closed ? (
+                <polygon
+                    points={pointsStr}
+                    fill={shape.fill || "rgba(34,197,94,0.08)"}
+                    stroke={shape.stroke || "#22c55e"}
+                    strokeWidth={2}
+                    strokeLinejoin="round"
+                    strokeLinecap="round"
+                    className="closed"
+                />
+            ) : (
+                <polyline
+                    points={pointsStr}
+                    fill="none"
+                    stroke={shape.stroke || "#22c55e"}
+                    strokeWidth={2}
+                    strokeLinejoin="round"
+                    strokeLinecap="round"
+                />
+            )}
 
             {selected && shape.points.map((point, i) => (
                 <HandleRenderer


### PR DESCRIPTION
## Summary
- render closed polylines as `<polygon>` elements while preserving fill and stroke styles
- keep existing handle rendering logic intact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a55a13c82883328f0b5a19202d704a