### PR TITLE
Handle device pixel ratio in canvas

### DIFF
--- a/src/components/ImageAnnotator/Canvas.tsx
+++ b/src/components/ImageAnnotator/Canvas.tsx
@@ -47,10 +47,16 @@ const Canvas = ({
     useEffect(() => {
         const cvs = canvasRef.current;
         if (!cvs) return;
-        cvs.width = width;
-        cvs.height = height;
         const ctx = cvs.getContext("2d");
         if (!ctx) return;
+
+        const dpr = window.devicePixelRatio || 1;
+        cvs.width = width * dpr;
+        cvs.height = height * dpr;
+        cvs.style.width = `${width}px`;
+        cvs.style.height = `${height}px`;
+        ctx.scale(dpr, dpr);
+
         ctx.clearRect(0, 0, width, height);
         if (!image) return;
 


### PR DESCRIPTION
## Summary
- Scale the canvas drawing surface based on `window.devicePixelRatio`
- Maintain CSS pixel dimensions so image and overlay remain aligned

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a55a170da88332ab09316603ca4b17