### PR TITLE
Fix cursor coordinate misalignment in image annotator

### DIFF
--- a/src/components/ImageAnnotator/index.tsx
+++ b/src/components/ImageAnnotator/index.tsx
@@ -158,7 +158,7 @@ const ImageAnnotator = () => {
             return;
         }
 
-        const mouse = getMousePoint(e, containerRef);
+        const mouse = getMousePoint(e);
         const img = screenToImage(mouse, zoom, pan);
 
         // Start drawing tools
@@ -206,7 +206,7 @@ const ImageAnnotator = () => {
             return;
         }
         if (!image) return;
-        const mouse = getMousePoint(e, containerRef);
+        const mouse = getMousePoint(e);
         const img = screenToImage(mouse, zoom, pan);
 
         // Update drafts

--- a/src/utils/coordinates.ts
+++ b/src/utils/coordinates.ts
@@ -15,14 +15,12 @@ export const imageToScreen = (p: Point, zoom: number, pan: Point): Point => {
 };
 
 export const getMousePoint = (
-    e: React.PointerEvent | PointerEvent,
-    containerRef: React.RefObject<HTMLDivElement | null>
-): Point  => {
-    if (!containerRef.current) return { x: 0, y: 0 };
-    const bounds = containerRef.current.getBoundingClientRect();
+    e: React.PointerEvent | PointerEvent
+): Point => {
+    const bounds = (e.currentTarget as Element).getBoundingClientRect();
     return {
         x: e.clientX - bounds.left,
-        y: e.clientY - bounds.top
+        y: e.clientY - bounds.top,
     };
 };
 


### PR DESCRIPTION
## Summary
- compute mouse coordinates relative to event target instead of root container to align pointer interactions
- update image annotator handlers to use revised helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a56af985548332966716ae4a350ea6