### PR TITLE
Fix rectangle corner dragging to resize both axes

### DIFF
--- a/src/hooks/useShapeManipulation.ts
+++ b/src/hooks/useShapeManipulation.ts
@@ -155,7 +155,7 @@ const useShapeManipulation = () => {
                 kind: hit.kind,
                 shapeId: hit.shape.id,
                 index: hit.index,
-                edge: hit.edge as "left" | "right" | "top" | "bottom" | undefined,
+                edge: hit.edge,
                 startMouseImg: imgPt,
                 startShape: JSON.parse(JSON.stringify(hit.shape)), // deep clone
             };
@@ -180,19 +180,21 @@ const useShapeManipulation = () => {
         } else if (start.type === "rect") {
             if (d.kind === "rect-corner" || d.kind === "rect-edge") {
                 const r = { ...start } as RectShape;
-                if (d.edge === "left") {
+                const e = d.edge ?? "";
+                if (e.includes("left")) {
                     const nx = r.x + dx;
                     const dw = r.x + r.w - nx;
                     r.x = nx;
                     r.w = dw;
-                } else if (d.edge === "right") {
+                } else if (e.includes("right")) {
                     r.w = r.w + dx;
-                } else if (d.edge === "top") {
+                }
+                if (e.includes("top")) {
                     const ny = r.y + dy;
                     const dh = r.y + r.h - ny;
                     r.y = ny;
                     r.h = dh;
-                } else if (d.edge === "bottom") {
+                } else if (e.includes("bottom")) {
                     r.h = r.h + dy;
                 }
                 updated = r;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,7 +69,7 @@ export type DragState =
             | "bezier-h2";
         shapeId: string;
         index?: number; // vertex/node index
-        edge?: "left" | "right" | "top" | "bottom"; // for rect edges
+        edge?: string; // identifies which rect edge or corner is dragged
         startMouseImg: Point;
         startShape: Shape;
     };

--- a/src/utils/hitTesting.ts
+++ b/src/utils/hitTesting.ts
@@ -20,9 +20,8 @@ const hitTest = (
             ];
             for (const [c, label] of corners) {
                 if (dist2(imgPt, c) <= tol * tol) {
-                    const edge = label.includes("left") ? "left" : "right";
-                    // corner drag uses both axes (edge signals which side changes)
-                    return { shape: s, kind: "rect-corner", edge };
+                    // For corners, store full label (e.g. "left top") so both axes can change
+                    return { shape: s, kind: "rect-corner", edge: label };
                 }
             }
             // edges


### PR DESCRIPTION
## Summary
- carry corner labels in hit testing so both axes are tracked
- update drag logic to resize rects vertically and horizontally
- loosen drag state type to store edge/corner labels

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

Closes #9 

------
https://chatgpt.com/codex/tasks/task_e_68a56f7eef2c8332b8f5fdb4330314d6