### PR TITLE
feat: add id and world coordinates to point annotations

### DIFF
--- a/src/components/shapes/PointRenderer.tsx
+++ b/src/components/shapes/PointRenderer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { type PointShape, type Point } from '../../types';
 
 interface PointRendererProps {
@@ -11,16 +11,57 @@ const PointRenderer: React.FC<PointRendererProps> = ({
     imageToScreen
 }) => {
     const screenPoint = imageToScreen(shape.p);
+    const [hover, setHover] = useState(false);
+    const [showCoords, setShowCoords] = useState(false);
+
+    const tooltipText = showCoords
+        ? (shape.world
+            ? `${shape.world.x.toFixed(2)}, ${shape.world.y.toFixed(2)}, ${shape.world.z.toFixed(2)}`
+            : `${shape.p.x.toFixed(2)}, ${shape.p.y.toFixed(2)}`)
+        : `ID: ${shape.interestId}`;
+
+    const padding = 4;
+    const width = tooltipText.length * 6 + padding * 2;
+    const height = 16;
+    const tooltipX = screenPoint.x + 6;
+    const tooltipY = screenPoint.y - height - 6;
 
     return (
-        <circle
-            cx={screenPoint.x}
-            cy={screenPoint.y}
-            r={4}
-            fill={shape.fill || "#f43f5e"}
-            stroke={shape.stroke || "#ffffff"}
-            strokeWidth={2}
-        />
+        <g
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => { setHover(false); setShowCoords(false); }}
+            onClick={() => setShowCoords(prev => !prev)}
+            style={{ cursor: 'pointer' }}
+        >
+            <circle
+                cx={screenPoint.x}
+                cy={screenPoint.y}
+                r={4}
+                fill={shape.fill || "#f43f5e"}
+                stroke={shape.stroke || "#ffffff"}
+                strokeWidth={2}
+            />
+            {hover && (
+                <g transform={`translate(${tooltipX}, ${tooltipY})`}>
+                    <rect
+                        width={width}
+                        height={height}
+                        rx={4}
+                        fill="#ffffff"
+                        stroke="#333333"
+                    />
+                    <text
+                        x={padding}
+                        y={height / 2}
+                        fontSize={12}
+                        fill="#111111"
+                        alignmentBaseline="middle"
+                    >
+                        {tooltipText}
+                    </text>
+                </g>
+            )}
+        </g>
     );
 };
 

--- a/src/hooks/useShapeManipulation.ts
+++ b/src/hooks/useShapeManipulation.ts
@@ -132,12 +132,15 @@ const useShapeManipulation = () => {
     };
 
     const createPoint = (imgPt: Point) => {
+        const pointIndex = shapes.filter(s => s.type === "point").length + 1;
         const pt: PointShape = {
             id: genId(),
             type: "point",
             p: imgPt,
             stroke: "#f43f5e",
             fill: "#f43f5e",
+            interestId: pointIndex,
+            world: { x: imgPt.x, y: imgPt.y, z: 0 }
         };
         setShapes((prev) => [...prev, pt]);
         setSelectedId(pt.id);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export type Tool = "select" | "pan" | "rect" | "poly" | "bezier" | "point";
 
 export type Point = { x: number; y: number };
+export type Point3 = { x: number; y: number; z: number };
 
 export type BaseShape = {
     id: string;
@@ -43,6 +44,10 @@ export type BezierShape = BaseShape & {
 export type PointShape = BaseShape & {
     type: "point";
     p: Point;
+    /** Optional numeric identifier for the point of interest */
+    interestId?: number;
+    /** Known 3D world coordinate for this point */
+    world?: Point3;
 };
 
 export type Shape = RectShape | PolylineShape | BezierShape | PointShape;

--- a/src/utils/shapeHelpers.ts
+++ b/src/utils/shapeHelpers.ts
@@ -108,7 +108,13 @@ export const moveShapeBy = (s: Shape, dx: number, dy: number): Shape => {
             })),
         };
     case "point":
-        return { ...s, p: { x: s.p.x + dx, y: s.p.y + dy } };
+        return {
+            ...s,
+            p: { x: s.p.x + dx, y: s.p.y + dy },
+            world: s.world
+                ? { x: s.world.x + dx, y: s.world.y + dy, z: s.world.z }
+                : undefined,
+        };
     }
 };
 


### PR DESCRIPTION
## Summary
- extend point shape to carry an interest id and optional 3D world coordinate
- show a styled tooltip for point shapes that toggles between id and precise coordinates on click
- propagate world coordinates when moving points and assign defaults when creating points

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b04d6d15e48332bc65681ae8e62aca