### PR TITLE
Add backend image upload and feature detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ An interactive React + TypeScript application for annotating images with sha
 - **Import/export**
   - Load images via file dialog or drag‑and‑drop
   - Export annotations as JSON, optionally embedding the source image (`annotation.json` or `annotation_bundle.json`)
+- **Backend integration**
+  - Upload images to an external image store service
+  - Request feature detection by image ID and feature type
 
 ## Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.3.1",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -21,7 +22,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
-        "tsx": "^4.20.4",
+        "tsx": "^4.20.5",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
         "vite": "^7.1.2"
@@ -1407,6 +1408,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.10",
@@ -3228,9 +3239,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.20.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
-      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3297,6 +3308,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsx src/**/*.test.ts"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.3.1",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
@@ -24,7 +25,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "tsx": "^4.20.4",
+    "tsx": "^4.20.5",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2"

--- a/src/components/ImageAnnotator/Toolbar.module.css
+++ b/src/components/ImageAnnotator/Toolbar.module.css
@@ -47,3 +47,10 @@
   color: var(--color-muted);
   padding: 0 0.5rem;
 }
+
+.featureInput {
+  width: 8rem;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}

--- a/src/components/ImageAnnotator/Toolbar.tsx
+++ b/src/components/ImageAnnotator/Toolbar.tsx
@@ -18,6 +18,10 @@ interface ToolbarProps {
     onImportJson: (ev: React.ChangeEvent<HTMLInputElement>) => void;
     onExportJson: () => void;
     onExportBundle: () => void;
+    featureType: string;
+    onFeatureTypeChange: (val: string) => void;
+    onDetectFeatures: () => void;
+    canDetect: boolean;
 };
 
 const Toolbar = ({
@@ -34,7 +38,11 @@ const Toolbar = ({
     onLoadImage,
     onImportJson,
     onExportJson,
-    onExportBundle
+    onExportBundle,
+    featureType,
+    onFeatureTypeChange,
+    onDetectFeatures,
+    canDetect
 }: ToolbarProps) => {
     return (
         <div className={styles.toolbar}>
@@ -66,6 +74,14 @@ const Toolbar = ({
                 </label>
                 <ToolButton onClick={onExportJson}>Export JSON</ToolButton>
                 <ToolButton onClick={onExportBundle}>Export Bundle</ToolButton>
+                <input
+                    className={styles.featureInput}
+                    type="text"
+                    value={featureType}
+                    onChange={(e) => onFeatureTypeChange(e.target.value)}
+                    placeholder="Feature"
+                />
+                <ToolButton onClick={onDetectFeatures} disabled={!canDetect}>Detect</ToolButton>
                 <div className={styles.zoomInfo}>Zoom: {(zoom * 100).toFixed(0)}%</div>
             </div>
         </div>

--- a/src/components/ImageAnnotator/index.tsx
+++ b/src/components/ImageAnnotator/index.tsx
@@ -11,6 +11,7 @@ import useImageLoader from '../../hooks/useImageLoader';
 import useShapeManipulation from '../../hooks/useShapeManipulation';
 import usePanZoom from '../../hooks/usePanZoom';
 import hitTest from '../../utils/hitTesting';
+import { requestFeatureDetection } from '../../utils/api';
 
 import { getMousePoint, screenToImage } from '../../utils/coordinates';
 import { exportJson } from '../../utils/fileHandlers';
@@ -43,9 +44,26 @@ const ImageAnnotator = () => {
     } = useShapeManipulation();
 
     const {
-        image, imageName,
+        image, imageName, imageId,
         handleFileInput, handleDrop, handleDragOver, handleImportJson
     } = useImageLoader(() => setShapes([]));
+
+    const [featureType, setFeatureType] = useState('faces');
+
+    const detectFeatures = async () => {
+        if (!imageId) {
+            alert('No image uploaded');
+            return;
+        }
+        try {
+            const result = await requestFeatureDetection(imageId, featureType);
+            // For now, simply log the result. Rendering can be added later.
+            console.log('Detected features', result);
+        } catch (err) {
+            console.error('Feature detection failed', err);
+            alert('Feature detection failed');
+        }
+    };
 
     const {
         beginOp, endOp, undo, redo, cancelOp, canUndo, canRedo
@@ -280,6 +298,10 @@ const ImageAnnotator = () => {
                 onImportJson={(e) => handleImportJson(e, setShapes)}
                 onExportJson={() => exportJson(shapes, image, imageName, false)}
                 onExportBundle={() => exportJson(shapes, image, imageName, true)}
+                featureType={featureType}
+                onFeatureTypeChange={setFeatureType}
+                onDetectFeatures={detectFeatures}
+                canDetect={Boolean(imageId)}
             />
 
             <Canvas

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+const env = (typeof import.meta !== 'undefined' && (import.meta as { env: Record<string, string> }).env) || (process.env as Record<string, string>);
+export const IMAGE_STORE_SERVICE_URL = env.VITE_IMAGE_STORE_SERVICE_URL ?? 'http://localhost:8000';
+export const FEATURE_DETECTION_SERVICE_URL = env.VITE_FEATURE_DETECTION_SERVICE_URL ?? 'http://localhost:8001';

--- a/src/hooks/useImageLoader.ts
+++ b/src/hooks/useImageLoader.ts
@@ -6,7 +6,7 @@ const useImageLoader = (onReset?: () => void) => {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [imageName, setImageName] = useState<string | undefined>(undefined);
     const [imageId, setImageId] = useState<string | null>(null);
-    
+
     // Track the current upload to prevent stale updates
     const currentUploadRef = useRef<string | null>(null);
 
@@ -26,7 +26,7 @@ const useImageLoader = (onReset?: () => void) => {
                 setImageName(file.name);
                 onReset?.();
             }
-            
+
             try {
                 const id = await uploadImage(file);
                 // Only update imageId if this upload is still current
@@ -60,7 +60,7 @@ const useImageLoader = (onReset?: () => void) => {
     const loadImageFromDataUrl = (dataUrl: string, name?: string) => {
         // Clear any pending uploads since we're loading from data URL
         currentUploadRef.current = null;
-        
+
         const img = new Image();
         img.onload = () => {
             setImage(img);

--- a/src/hooks/useImageLoader.ts
+++ b/src/hooks/useImageLoader.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { type AnnotationBundle, type Shape } from '../types';
 import { uploadImage } from '../utils/api';
 
@@ -6,26 +6,47 @@ const useImageLoader = (onReset?: () => void) => {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [imageName, setImageName] = useState<string | undefined>(undefined);
     const [imageId, setImageId] = useState<string | null>(null);
+    
+    // Track the current upload to prevent stale updates
+    const currentUploadRef = useRef<string | null>(null);
 
     const loadImageFromFile = (file: File) => {
         if (!file || !file.type.startsWith('image/')) return;
 
+        // Generate a unique token for this upload
+        const uploadToken = Math.random().toString(36);
+        currentUploadRef.current = uploadToken;
+
         setImageId(null);
         const img = new Image();
         img.onload = async () => {
-            setImage(img);
-            setImageName(file.name);
-            onReset?.();
+            // Only update if this is still the current upload
+            if (currentUploadRef.current === uploadToken) {
+                setImage(img);
+                setImageName(file.name);
+                onReset?.();
+            }
+            
             try {
                 const id = await uploadImage(file);
-                setImageId(id);
+                // Only update imageId if this upload is still current
+                if (currentUploadRef.current === uploadToken) {
+                    setImageId(id);
+                }
             } catch (err) {
                 console.error('Failed to upload image', err);
+                // Only show error if this upload is still current
+                if (currentUploadRef.current === uploadToken) {
+                    // Error handling for current upload only
+                }
             }
         };
 
         img.onerror = () => {
-            alert("Failed to load image. Please try a different file.");
+            // Only show error if this upload is still current
+            if (currentUploadRef.current === uploadToken) {
+                alert("Failed to load image. Please try a different file.");
+            }
         };
 
         // Use FileReader to support environments where object URLs are restricted
@@ -37,6 +58,9 @@ const useImageLoader = (onReset?: () => void) => {
     };
 
     const loadImageFromDataUrl = (dataUrl: string, name?: string) => {
+        // Clear any pending uploads since we're loading from data URL
+        currentUploadRef.current = null;
+        
         const img = new Image();
         img.onload = () => {
             setImage(img);

--- a/src/hooks/useImageLoader.ts
+++ b/src/hooks/useImageLoader.ts
@@ -1,18 +1,27 @@
 import { useState } from 'react';
 import { type AnnotationBundle, type Shape } from '../types';
+import { uploadImage } from '../utils/api';
 
 const useImageLoader = (onReset?: () => void) => {
     const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [imageName, setImageName] = useState<string | undefined>(undefined);
+    const [imageId, setImageId] = useState<string | null>(null);
 
     const loadImageFromFile = (file: File) => {
         if (!file || !file.type.startsWith('image/')) return;
 
+        setImageId(null);
         const img = new Image();
-        img.onload = () => {
+        img.onload = async () => {
             setImage(img);
             setImageName(file.name);
             onReset?.();
+            try {
+                const id = await uploadImage(file);
+                setImageId(id);
+            } catch (err) {
+                console.error('Failed to upload image', err);
+            }
         };
 
         img.onerror = () => {
@@ -32,6 +41,7 @@ const useImageLoader = (onReset?: () => void) => {
         img.onload = () => {
             setImage(img);
             setImageName(name);
+            setImageId(null);
             onReset?.();
         };
         img.src = dataUrl;
@@ -91,6 +101,7 @@ const useImageLoader = (onReset?: () => void) => {
     return {
         image,
         imageName,
+        imageId,
         loadImageFromFile,
         loadImageFromDataUrl,
         handleFileInput,

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -1,0 +1,43 @@
+/* eslint-env node */
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { uploadImage, requestFeatureDetection } from './api';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test('uploadImage posts file and returns id', async () => {
+    const file = new File(['data'], 'test.png', { type: 'image/png' });
+    const expectedId = 'abc123';
+    globalThis.fetch = async (input, init) => {
+        assert.equal(input, 'http://localhost:8000/images');
+        const req = init as RequestInit;
+        assert.equal(req.method, 'POST');
+        const body = req.body as FormData;
+        const uploaded = body.get('file') as File;
+        assert.equal(uploaded.name, 'test.png');
+        return new Response(JSON.stringify({ id: expectedId }), { status: 200 });
+    };
+    const id = await uploadImage(file);
+    assert.equal(id, expectedId);
+});
+
+test('requestFeatureDetection sends correct payload', async () => {
+    const imageId = 'img1';
+    const featureType = 'faces';
+    const response = { features: [] };
+    globalThis.fetch = async (input, init) => {
+        assert.equal(input, 'http://localhost:8001/detect');
+        const req = init as RequestInit;
+        assert.equal(req.method, 'POST');
+        const headers = req.headers as Record<string, string>;
+        assert.equal(headers['Content-Type'], 'application/json');
+        const body = JSON.parse(String(req.body));
+        assert.deepEqual(body, { image_id: imageId, feature_type: featureType });
+        return new Response(JSON.stringify(response), { status: 200 });
+    };
+    const data = await requestFeatureDetection(imageId, featureType);
+    assert.deepEqual(data, response);
+});

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,28 @@
+import { IMAGE_STORE_SERVICE_URL, FEATURE_DETECTION_SERVICE_URL } from '../constants';
+
+export async function uploadImage(file: File): Promise<string> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const res = await fetch(`${IMAGE_STORE_SERVICE_URL}/images`, {
+        method: 'POST',
+        body: formData,
+    });
+    if (!res.ok) {
+        throw new Error(`Failed to upload image: ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json() as { id: string };
+    return data.id;
+}
+
+export async function requestFeatureDetection(imageId: string, featureType: string): Promise<unknown> {
+    const res = await fetch(`${FEATURE_DETECTION_SERVICE_URL}/detect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image_id: imageId, feature_type: featureType }),
+    });
+    if (!res.ok) {
+        throw new Error(`Feature detection failed: ${res.status} ${res.statusText}`);
+    }
+    return res.json();
+}


### PR DESCRIPTION
## Summary
- upload loaded images to the image store service
- add feature detection requests with configurable feature type
- document backend integration and add unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baeaf875848332b696ce5f13f979bb