### PR TITLE
Adapt feature detection request to new API

### DIFF
--- a/src/components/ImageAnnotator/Toolbar.module.css
+++ b/src/components/ImageAnnotator/Toolbar.module.css
@@ -54,3 +54,17 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
+
+.paramInput {
+  width: 5rem;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}

--- a/src/components/ImageAnnotator/Toolbar.tsx
+++ b/src/components/ImageAnnotator/Toolbar.tsx
@@ -18,8 +18,10 @@ interface ToolbarProps {
     onImportJson: (ev: React.ChangeEvent<HTMLInputElement>) => void;
     onExportJson: () => void;
     onExportBundle: () => void;
-    featureType: string;
-    onFeatureTypeChange: (val: string) => void;
+    pattern: string;
+    params: Record<string, unknown>;
+    onPatternChange: (val: string) => void;
+    onParamsChange: (params: Record<string, unknown>) => void;
     onDetectFeatures: () => void;
     canDetect: boolean;
 };
@@ -39,11 +41,120 @@ const Toolbar = ({
     onImportJson,
     onExportJson,
     onExportBundle,
-    featureType,
-    onFeatureTypeChange,
+    pattern,
+    params,
+    onPatternChange,
+    onParamsChange,
     onDetectFeatures,
     canDetect
 }: ToolbarProps) => {
+    const updateParam = (key: string, value: unknown) => {
+        onParamsChange({ ...params, [key]: value });
+    };
+
+    const renderParamInputs = () => {
+        switch (pattern) {
+            case 'charuco':
+                return (
+                    <>
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.squares_x as number) ?? ''}
+                            onChange={(e) => updateParam('squares_x', parseInt(e.target.value, 10))}
+                            placeholder="Squares X"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.squares_y as number) ?? ''}
+                            onChange={(e) => updateParam('squares_y', parseInt(e.target.value, 10))}
+                            placeholder="Squares Y"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.square_length as number) ?? ''}
+                            onChange={(e) => updateParam('square_length', parseFloat(e.target.value))}
+                            placeholder="Square Len"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.marker_length as number) ?? ''}
+                            onChange={(e) => updateParam('marker_length', parseFloat(e.target.value))}
+                            placeholder="Marker Len"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="text"
+                            value={(params.dictionary as string) ?? ''}
+                            onChange={(e) => updateParam('dictionary', e.target.value)}
+                            placeholder="Dictionary"
+                        />
+                    </>
+                );
+            case 'circle_grid':
+                return (
+                    <>
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.rows as number) ?? ''}
+                            onChange={(e) => updateParam('rows', parseInt(e.target.value, 10))}
+                            placeholder="Rows"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.cols as number) ?? ''}
+                            onChange={(e) => updateParam('cols', parseInt(e.target.value, 10))}
+                            placeholder="Cols"
+                        />
+                        <label className={styles.checkboxLabel}>
+                            Symmetric
+                            <input
+                                type="checkbox"
+                                checked={Boolean(params.symmetric)}
+                                onChange={(e) => updateParam('symmetric', e.target.checked)}
+                            />
+                        </label>
+                    </>
+                );
+            case 'chessboard':
+                return (
+                    <>
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.rows as number) ?? ''}
+                            onChange={(e) => updateParam('rows', parseInt(e.target.value, 10))}
+                            placeholder="Rows"
+                        />
+                        <input
+                            className={styles.paramInput}
+                            type="number"
+                            value={(params.cols as number) ?? ''}
+                            onChange={(e) => updateParam('cols', parseInt(e.target.value, 10))}
+                            placeholder="Cols"
+                        />
+                    </>
+                );
+            case 'apriltag':
+                return (
+                    <input
+                        className={styles.paramInput}
+                        type="text"
+                        value={(params.dictionary as string) ?? ''}
+                        onChange={(e) => updateParam('dictionary', e.target.value)}
+                        placeholder="Dictionary"
+                    />
+                );
+            default:
+                return null;
+        }
+    };
+
     return (
         <div className={styles.toolbar}>
             <div className={styles.group}>
@@ -74,13 +185,17 @@ const Toolbar = ({
                 </label>
                 <ToolButton onClick={onExportJson}>Export JSON</ToolButton>
                 <ToolButton onClick={onExportBundle}>Export Bundle</ToolButton>
-                <input
+                <select
                     className={styles.featureInput}
-                    type="text"
-                    value={featureType}
-                    onChange={(e) => onFeatureTypeChange(e.target.value)}
-                    placeholder="Feature"
-                />
+                    value={pattern}
+                    onChange={(e) => onPatternChange(e.target.value)}
+                >
+                    <option value="chessboard">Chessboard</option>
+                    <option value="charuco">ChArUco</option>
+                    <option value="circle_grid">Circle Grid</option>
+                    <option value="apriltag">AprilTag</option>
+                </select>
+                {renderParamInputs()}
                 <ToolButton onClick={onDetectFeatures} disabled={!canDetect}>Detect</ToolButton>
                 <div className={styles.zoomInfo}>Zoom: {(zoom * 100).toFixed(0)}%</div>
             </div>

--- a/src/components/ImageAnnotator/index.tsx
+++ b/src/components/ImageAnnotator/index.tsx
@@ -48,7 +48,28 @@ const ImageAnnotator = () => {
         handleFileInput, handleDrop, handleDragOver, handleImportJson
     } = useImageLoader(() => setShapes([]));
 
-    const [featureType, setFeatureType] = useState('faces');
+    const [pattern, setPattern] = useState('chessboard');
+    const [patternParams, setPatternParams] = useState<Record<string, unknown>>({ rows: 7, cols: 7 });
+
+    const handlePatternChange = (p: string) => {
+        setPattern(p);
+        switch (p) {
+            case 'charuco':
+                setPatternParams({ squares_x: 5, squares_y: 7, square_length: 1.0, marker_length: 0.5, dictionary: 'DICT_4X4_50' });
+                break;
+            case 'circle_grid':
+                setPatternParams({ rows: 4, cols: 5, symmetric: true });
+                break;
+            case 'chessboard':
+                setPatternParams({ rows: 7, cols: 7 });
+                break;
+            case 'apriltag':
+                setPatternParams({ dictionary: 'DICT_APRILTAG_36h11' });
+                break;
+            default:
+                setPatternParams({});
+        }
+    };
 
     const detectFeatures = async () => {
         if (!imageId) {
@@ -56,7 +77,7 @@ const ImageAnnotator = () => {
             return;
         }
         try {
-            const result = await requestFeatureDetection(imageId, featureType);
+            const result = await requestFeatureDetection(imageId, pattern, patternParams);
             // For now, simply log the result. Rendering can be added later.
             console.log('Detected features', result);
         } catch (err) {
@@ -298,8 +319,10 @@ const ImageAnnotator = () => {
                 onImportJson={(e) => handleImportJson(e, setShapes)}
                 onExportJson={() => exportJson(shapes, image, imageName, false)}
                 onExportBundle={() => exportJson(shapes, image, imageName, true)}
-                featureType={featureType}
-                onFeatureTypeChange={setFeatureType}
+                pattern={pattern}
+                params={patternParams}
+                onPatternChange={handlePatternChange}
+                onParamsChange={setPatternParams}
                 onDetectFeatures={detectFeatures}
                 canDetect={Boolean(imageId)}
             />

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -26,18 +26,24 @@ test('uploadImage posts file and returns id', async () => {
 
 test('requestFeatureDetection sends correct payload', async () => {
     const imageId = 'img1';
-    const featureType = 'faces';
-    const response = { features: [] };
+    const pattern = 'chessboard';
+    const params = { rows: 7, cols: 7 };
+    const response = { points: [] };
     globalThis.fetch = async (input, init) => {
-        assert.equal(input, 'http://localhost:8001/detect');
+        assert.equal(input, 'http://localhost:8001/detect_pattern');
         const req = init as RequestInit;
         assert.equal(req.method, 'POST');
         const headers = req.headers as Record<string, string>;
         assert.equal(headers['Content-Type'], 'application/json');
         const body = JSON.parse(String(req.body));
-        assert.deepEqual(body, { image_id: imageId, feature_type: featureType });
+        assert.deepEqual(body, {
+            image_id: imageId,
+            pattern,
+            params,
+            return_overlay: false,
+        });
         return new Response(JSON.stringify(response), { status: 200 });
     };
-    const data = await requestFeatureDetection(imageId, featureType);
+    const data = await requestFeatureDetection(imageId, pattern, params);
     assert.deepEqual(data, response);
 });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -15,11 +15,21 @@ export async function uploadImage(file: File): Promise<string> {
     return data.id;
 }
 
-export async function requestFeatureDetection(imageId: string, featureType: string): Promise<unknown> {
-    const res = await fetch(`${FEATURE_DETECTION_SERVICE_URL}/detect`, {
+export async function requestFeatureDetection(
+    imageId: string,
+    pattern: string,
+    params: Record<string, unknown> = {},
+    returnOverlay = false,
+): Promise<unknown> {
+    const res = await fetch(`${FEATURE_DETECTION_SERVICE_URL}/detect_pattern`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image_id: imageId, feature_type: featureType }),
+        body: JSON.stringify({
+            image_id: imageId,
+            pattern,
+            params,
+            return_overlay: returnOverlay,
+        }),
     });
     if (!res.ok) {
         throw new Error(`Feature detection failed: ${res.status} ${res.statusText}`);


### PR DESCRIPTION
## Summary
- update feature detection request to send pattern, params and overlay flags
- rename toolbar inputs and ImageAnnotator state to `pattern`
- implement dropdown selection and parameter forms for all supported patterns
- adjust tests for new `detect_pattern` endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbe87c45808332a89c983e1bac1111