### PR TITLE
Disable image smoothing when zoomed in

### DIFF
--- a/src/components/ImageAnnotator/Canvas.module.css
+++ b/src/components/ImageAnnotator/Canvas.module.css
@@ -8,6 +8,7 @@
 .canvas {
   position: absolute;
   inset: 0;
+  image-rendering: pixelated;
 }
 
 .hint {

--- a/src/components/ImageAnnotator/Canvas.tsx
+++ b/src/components/ImageAnnotator/Canvas.tsx
@@ -65,8 +65,8 @@ const Canvas = ({
         const y = pan.y;
         const w = iw * zoom;
         const h = ih * zoom;
-        ctx.imageSmoothingEnabled = true;
-        ctx.imageSmoothingQuality = "high";
+        ctx.imageSmoothingEnabled = zoom < 1;
+        ctx.imageSmoothingQuality = zoom < 1 ? "high" : "low";
         ctx.drawImage(image, 0, 0, iw, ih, x, y, w, h);
     }, [image, zoom, pan, width, height]);
 


### PR DESCRIPTION
## Summary
- Prevent canvas image smoothing when zoomed so pixels remain crisp
- Apply CSS to ensure pixelated rendering of the canvas

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc1c77b3488332a5604d201b46f63a